### PR TITLE
Fix “error: can't copy 'SeetaFaceEngine/Release/FaceDetection': doesn't exist or not a regular file”  

### DIFF
--- a/pyseeta/config.py
+++ b/pyseeta/config.py
@@ -17,6 +17,12 @@ config = {
         'detector': 'libseeta_fd_lib.so',
         'aligner': 'libseeta_fa_lib.so',
         'identifier': 'libseeta_fi_lib.so'
+    },
+    # Ubuntu 16.04 x64 Python 2.7.12 (default, Nov 19 2016, 06:48:10) sys.platform return 'linux2'
+    'linux2': {
+        'detector': 'libseeta_fd_lib.so',
+        'aligner': 'libseeta_fa_lib.so',
+        'identifier': 'libseeta_fi_lib.so'
     }
 }
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,14 @@ from setuptools import setup, find_packages
 import sys, os
 
 dylib_dir = 'SeetaFaceEngine/Release'
-dylibs = [os.path.join(dylib_dir, x) for x in os.listdir(dylib_dir)]
+cpylibs = [os.path.join(dylib_dir, x) for x in os.listdir(dylib_dir)]
+
+dylibs = []
+#print cpylibs
+for f in cpylibs :
+	if os.path.isfile(f) :
+		dylibs.append(f)
+#print dylibs
 
 setup(
     name ='pyseeta',


### PR DESCRIPTION
Fix “error: can't copy 'SeetaFaceEngine/Release/FaceDetection': doesn't exist or not a regular file”

data_files section do not allow dir 